### PR TITLE
リレーション：todo_tagテーブルテスト用のSQLiteデータを追加

### DIFF
--- a/practical-fastapi/src/test/conftest.py
+++ b/practical-fastapi/src/test/conftest.py
@@ -6,6 +6,7 @@ from sqlalchemy_utils import database_exists, drop_database
 from app.database import Base
 from models.tag import TagModel
 from models.todo import TodoModel
+from models.todo_tag import TodoTagModel
 
 
 ## ここではSQLiteを使ったユニットテストの共通部分を書く
@@ -37,9 +38,11 @@ def SessionLocal():
 
     # リレーションの作り方
     # 呼び出す
-    # new_todo = TodoModel(content = "買い物する")
-    # session.add(new_todo)
-    # 上記のようにデータを挿入する
+    new_todo_tag = TodoTagModel(todo_id="1", tag_id="1")
+    session.add(new_todo_tag)
+    new_todo_tag = TodoTagModel(todo_id="1", tag_id="2")
+    session.add(new_todo_tag)
+    session.commit()
 
     yield SessionLocal
 

--- a/practical-fastapi/src/test/conftest.py
+++ b/practical-fastapi/src/test/conftest.py
@@ -29,11 +29,17 @@ def SessionLocal():
     session.add(new_tag)
     session.commit()
 
-    new_todo = TodoModel(content = "買い物する")
+    new_todo = TodoModel(content="買い物する")
     session.add(new_todo)
-    new_todo = TodoModel(content = "帰宅する")
+    new_todo = TodoModel(content="帰宅する")
     session.add(new_todo)
     session.commit()
+
+    # リレーションの作り方
+    # 呼び出す
+    # new_todo = TodoModel(content = "買い物する")
+    # session.add(new_todo)
+    # 上記のようにデータを挿入する
 
     yield SessionLocal
 


### PR DESCRIPTION
## 概要
TodoのUpdateで処理されるtodo_tagテーブルのテスト用データをSQLiteに挿入

## 背景
ユニットテストのため

## その他
SQLiteに対してはユニットテスト用関数がないため、テーブルに対しての操作は未実施