### PR TITLE
各apiにjwt検証機能を追加

### DIFF
--- a/front/app/api/Login/route.ts
+++ b/front/app/api/Login/route.ts
@@ -41,18 +41,15 @@ export async function POST(req: NextRequest) {
       user_id: responseUserId
     };
 
-    const token = jwt.sign(payload, secretKey, { expiresIn: '10s' });
+    const token = jwt.sign(payload, secretKey, { expiresIn: '10h' });
 
     response.cookies.set({
       name: "auth-token",
       value: token,
       httpOnly: true,
       path: "/",
-      maxAge: 60 * 60
+      maxAge: 60 * 60 * 10
     })
   }
   return response
 }
-
-// 現状の問題
-// シークレットキーをenvに入れる

--- a/front/app/api/TagDELETE/[id]/route.ts
+++ b/front/app/api/TagDELETE/[id]/route.ts
@@ -1,7 +1,14 @@
-import { NextApiRequest } from 'next';
+import { NextRequest, NextResponse } from 'next/server';
+import { auth_jwt } from '../../auth';
 
-export async function DELETE(req: NextApiRequest,
+export async function DELETE(req: NextRequest,
   { params }:{params: {id : string}}){
+
+  const res_auth = await auth_jwt(req)
+  if (!res_auth) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401});
+  }
+
   const id = params.id
   // リクエストヘッダーにCORS関連の設定を追加
   const headers = new Headers();

--- a/front/app/api/TagGETAll/route.ts
+++ b/front/app/api/TagGETAll/route.ts
@@ -1,4 +1,5 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { auth_jwt } from '../auth';
 
 // export async function GET() {
 //   const response = await fetch('http://127.0.0.1:8000/v1/tag',{
@@ -11,7 +12,11 @@ import { NextResponse } from 'next/server';
 const headers = new Headers();
 headers.append('Access-Control-Allow-Origin', '*'); 
 
-export async function GET() {
+export async function GET(req: NextRequest) {
+  const res_auth = await auth_jwt(req)
+  if (!res_auth) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401});
+  }
   const response = await fetch('http://127.0.0.1:8000/v1/tag',{
     cache: "no-store",
     method: 'GET',

--- a/front/app/api/TagPOST/route.ts
+++ b/front/app/api/TagPOST/route.ts
@@ -1,15 +1,23 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { auth_jwt } from '../auth';
 
 //export async function POST(req: NextApiRequest, res: NextApiResponse) {
-export async function POST(req: Request, res: NextApiResponse) {
+export async function POST(req: NextRequest, res: NextApiResponse) {
+
+  const res_auth = await auth_jwt(req)
+  if (!res_auth) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401});
+  }
+
   // リクエストヘッダーにCORS関連の設定を追加
   const headers = new Headers();
   //必須
   headers.append("Content-Type", "application/json");
   headers.append('Access-Control-Allow-Origin', '*'); // これはテスト用の設定で、実際のプロダクション環境では '*' を使用しないでください。
-  console.log(req.body)
-  const data = await req.json();
+  const body = await req.text();
+  console.log(body);
+  const data = await JSON.parse(body)
   await fetch('http://127.0.0.1:8000/v1/tag', {
     cache: "no-store",
     method: 'POST',

--- a/front/app/api/TodoDELETE/[id]/route.ts
+++ b/front/app/api/TodoDELETE/[id]/route.ts
@@ -1,7 +1,15 @@
-import { NextApiRequest, NextApiResponse } from 'next';
+import { NextRequest, NextResponse } from 'next/server';
+import { auth_jwt } from '../../auth';
 
-export async function DELETE(req: NextApiRequest,
+export async function DELETE(req: NextRequest,
   { params }:{params: {id : string}}){
+
+  // 認可機能
+  const res_auth = await auth_jwt(req)
+  if (!res_auth) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401});
+  }
+
   const id = params.id
   // リクエストヘッダーにCORS関連の設定を追加
   const headers = new Headers();

--- a/front/app/api/TodoGETById/[id]/route.ts
+++ b/front/app/api/TodoGETById/[id]/route.ts
@@ -1,7 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth_jwt } from '../../auth';
+
 export const fetchCache = 'default-no-store';
 
-export async function GET({ params }:{params: {id : string}})
+export async function GET(req: NextRequest ,{ params }:{params: {id : string}})
 {
+
+    // 認可機能
+    const res_auth = await auth_jwt(req)
+    if (!res_auth) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401});
+    }
+
   const id = params.id
 
   const headers = new Headers();

--- a/front/app/api/TodoPUTCompleted/[id]/route.ts
+++ b/front/app/api/TodoPUTCompleted/[id]/route.ts
@@ -1,7 +1,14 @@
-// import { NextApiRequest, NextApiResponse } from 'next';
+import { NextRequest, NextResponse } from 'next/server';
+import { auth_jwt } from '../../auth';
 
-export async function PUT(req: Request,
+export async function PUT(req: NextRequest,
   { params }:{params: {id : string}}){
+
+  const res_auth = await auth_jwt(req)
+  if (!res_auth) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401});
+  }
+
   // リクエストヘッダーにCORS関連の設定を追加
   const headers = new Headers();
   //必須
@@ -11,9 +18,10 @@ export async function PUT(req: Request,
   const id = params.id
 
   // const flg = Boolean(req.json)
-  const comp= await req.json();
 
-  console.log(comp)
+  const body = await req.text();
+  console.log(body);
+  const comp = await JSON.parse(body)
   let url = `http://127.0.0.1:8000/v1/todo/` + id;
 
     // FastAPIにPUTリクエストを送信し、completedを切り替え

--- a/front/app/api/TodoPUTDetail/[id]/route.ts
+++ b/front/app/api/TodoPUTDetail/[id]/route.ts
@@ -1,15 +1,24 @@
-export async function PUT(req: Request,
+import { NextRequest, NextResponse } from 'next/server';
+import { auth_jwt } from '../../auth';
+
+export async function PUT(req: NextRequest,
     { params }:{params: {id : string}}){
+
+    const res_auth = await auth_jwt(req)
+    if (!res_auth) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401});
+    }
+
     // リクエストヘッダーにCORS関連の設定を追加
     const headers = new Headers();
     headers.append('Access-Control-Allow-Origin', '*'); 
     headers.append("Content-Type", "application/json");
   
     const id = params.id
-  
-    const Up= await req.json();
-  
-    console.log(Up)
+
+    const body = await req.text();
+    const Up = await JSON.parse(body)
+    console.log(Up);
     let url = `http://127.0.0.1:8000/v1/todo/` + id;
   
     const res = await fetch(url, {

--- a/front/app/api/TodoPUTTag/route.ts
+++ b/front/app/api/TodoPUTTag/route.ts
@@ -1,12 +1,21 @@
-export async function PUT(req: Request){
+import { NextRequest, NextResponse } from 'next/server';
+import { auth_jwt } from '../auth';
+
+export async function PUT(req: NextRequest){
+
+  const res_auth = await auth_jwt(req)
+  if (!res_auth) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401});
+  }
+
     // リクエストヘッダーにCORS関連の設定を追加
     const headers = new Headers();
     headers.append('Access-Control-Allow-Origin', '*'); 
     headers.append("Content-Type", "application/json");
   
-    const Up= await req.json();
-  
-    console.log(Up)
+    const body = await req.text();
+    const Up = await JSON.parse(body)
+    console.log(Up);
     let url = `http://127.0.0.1:8000/v1/todo/`;
   
     const res = await fetch(url, {


### PR DESCRIPTION
ログイン以外の全APIにjwt検証機能を追加
これにより、ログイン時に得たトークンを持っていないと全ての動作において401を返されることになる。
また、作成中にログインをこまめにするのは苦なので、トークンの制限時間を意図的に10時間に延長している。