### PR TITLE
トークン切れ時にログイン画面へ遷移させる機能を追加

### DIFF
--- a/front/app/Compornents/Header.tsx
+++ b/front/app/Compornents/Header.tsx
@@ -1,5 +1,6 @@
 'use client'
 import React, { useState, useEffect } from 'react';
+import { useRouter } from "next/navigation";
 
 interface TodoPOST {
   content: string;
@@ -27,9 +28,15 @@ export default function Header() {
   const [isTagModalOpen, setIsTagModalOpen] = useState<boolean>(false);
   const [newTagName, setNewTagName] = useState<string>("");
 
+  const router = useRouter();
+
   const fetchTagData  = async () => {
     try {
       const response = await fetch('/api/TagGETAll');
+      if (response.status === 401) {
+        router.push("../Login/");
+        return
+      }
       if (!response.ok) {
         throw new Error(`HTTP error! Status: ${response.status}`);
       }
@@ -98,8 +105,11 @@ export default function Header() {
       },
       body: JSON.stringify(requestBody),
     });
-
-    if (res.ok) {
+    
+    if (res.status === 401) {
+      router.push("../Login/");
+      return
+    }else if (res.ok) {
       // Todoが正常に作成された場合
       // const createdTodo = await res.json(); // 新しく作成されたTodoの情報を取得
 
@@ -118,10 +128,10 @@ export default function Header() {
       // });
 
       // if (tagRes.ok) {
-      alert('Todo created successfully!');
-      location.reload();
+      await alert('Todo created successfully!');
+      await location.reload();
     } else {
-      alert('Failed to create Todo.');
+      await alert('Failed to create Todo.');
     }
 
     closeModal();
@@ -141,6 +151,10 @@ const handleDELETETags = async (): Promise<void> => {
           method: 'DELETE',
         });
 
+        if (res.status === 401) {
+          router.push("../Login/");
+          return
+        }
         if (res.ok) {
           
         } else {
@@ -176,6 +190,10 @@ const handleCreateTag = async (): Promise<void> => {
       body: JSON.stringify({ name: newTagName }),
     });
 
+    if (res.status === 401) {
+      router.push("../Login/");
+      return
+    }
     if (res.ok) {
       fetchTagData();
       setNewTagName("");

--- a/front/app/Compornents/TableCompornents/TodoGETAll.tsx
+++ b/front/app/Compornents/TableCompornents/TodoGETAll.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-
+import { useRouter } from "next/navigation";
 interface Todo {
   id: number;
   content: string;
@@ -32,9 +32,15 @@ function TodoList() {
   // const [time, setTime] = useState<string>("");
   const [isUpdated, setIsUpdated] = useState(false);
 
+  const router = useRouter();
+
   const fetchTodoData = async () => {
     try {
       const response = await fetch('/api/TodoGETAll');
+      if (response.status === 401) {
+        router.push("../Login/");
+        return
+      }
       if (!response.ok) {
         throw new Error(`HTTP error! Status: ${response.status}`);
       }
@@ -52,6 +58,10 @@ function TodoList() {
   const fetchTagData  = async () => {
     try {
       const response = await fetch('/api/TagGETAll');
+      if (response.status === 401) {
+        router.push("../Login/");
+        return
+      }
       if (!response.ok) {
         throw new Error(`HTTP error! Status: ${response.status}`);
       }
@@ -100,6 +110,10 @@ function TodoList() {
         const response = await fetch(`/api/TodoDELETE/${selectedId}`, {
           method: 'DELETE',
         });
+        if (response.status === 401) {
+          router.push("../Login/");
+          return
+        }
         if (response.ok) {
           console.log(`Successfully deleted Todo with ID ${selectedId}`);
         } else {
@@ -159,7 +173,11 @@ function TodoList() {
         },
         body: JSON.stringify(requestBody),
       });
-  
+
+      if (response.status === 401) {
+        router.push("../Login/");
+        return
+      }
       if (response.ok) {
         console.log(`Successfully updated Todo with ID ${selectedTodoId}`);
       } else {

--- a/front/app/api/Login/route.ts
+++ b/front/app/api/Login/route.ts
@@ -48,7 +48,7 @@ export async function POST(req: NextRequest) {
       value: token,
       httpOnly: true,
       path: "/",
-      maxAge: 60 * 60 * 10
+      maxAge: 60 * 60 * 10       // ブラウザ上では世界標準時間で表示されるので注意(ちゃんと指定した時間分消えないので大丈夫)
     })
   }
   return response

--- a/front/app/api/TodoPOST/route.ts
+++ b/front/app/api/TodoPOST/route.ts
@@ -1,15 +1,24 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { NextResponse } from 'next/server';
+import { NextRequest,NextResponse } from 'next/server';
+import { auth_jwt } from '../auth';
 
 //export async function POST(req: NextApiRequest, res: NextApiResponse) {
-export async function POST(req: Request, res: NextApiResponse) {
+export async function POST(req: NextRequest, res: NextApiResponse) {
+
+  // 認可機能
+  const res_auth = await auth_jwt(req)
+  if (!res_auth) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401});
+  }
+
   // リクエストヘッダーにCORS関連の設定を追加
   const headers = new Headers();
   //必須
   headers.append("Content-Type", "application/json");
   headers.append('Access-Control-Allow-Origin', '*'); // これはテスト用の設定で、実際のプロダクション環境では '*' を使用しないでください。
-  console.log(req.body)
-  const data = await req.json();
+  const body = await req.text();
+  console.log(body);
+  const data = await JSON.parse(body)
   await fetch('http://127.0.0.1:8000/v1/todo', {
     cache: "no-store",
     method: 'POST',


### PR DESCRIPTION
ステータスコード401を受け取った際にログイン画面へ遷移させる機能を、クライアント側の各通信コードに付与しました。
また、next.sj api側に一つトークン検証を行う機能をつけ忘れている部分があったので追記しました。